### PR TITLE
fix: add missing dummy_data_file

### DIFF
--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -1,3 +1,4 @@
+import pathlib
 import shlex
 from collections import defaultdict
 from typing import Any, Dict, Iterable, List, Optional, Set, TypedDict
@@ -93,6 +94,7 @@ class Action(BaseModel):
     run: Command
     needs: List[str] = []
     outputs: Outputs
+    dummy_data_file: Optional[pathlib.Path]
 
     @validator("run", pre=True)
     def parse_run_string(cls, run: str) -> Command:

--- a/pipeline/types.py
+++ b/pipeline/types.py
@@ -7,6 +7,7 @@ dictionary data.
 """
 from __future__ import annotations
 
+import pathlib
 from typing import Any, Dict, TypedDict
 
 
@@ -18,6 +19,7 @@ class RawAction(TypedDict):
     run: str
     needs: list[str] | None
     outputs: RawOutputs
+    dummy_data_file: pathlib.Path | None
 
 
 class RawExpectations(TypedDict):


### PR DESCRIPTION
This was removed, in error, because we don't test it in the pipeline
library.  However, job-runner makes use of it when running
cohortextractor actions.