### PR TITLE
Build Package with setuptools-scm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,32 @@ jobs:
       - name: Run tests
         run: just test
 
+  test-package-build:
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+
+    runs-on: ubuntu-latest
+
+    name: Test we can build a Python package
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Python ${{ matrix.python-vesrion }}
+        uses: "actions/setup-python@v3"
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: extractions/setup-just@v1
+
+      - name: Check the wheel installs and runs
+        run: just package-test wheel
+
+      - name: Check the sdist installs and runs
+        run: just package-test sdist
+
   tag-new-version:
-    needs: [check, test]
+    needs: [check, test, test-package-build]
     runs-on: ubuntu-latest
 
     if: github.ref == 'refs/heads/main'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "opensafely-pipeline"
 description = "OpenSAFELY pipeline configuration parsing library"
-version = "1+local"
 readme = "README.md"
 authors = [{name = "OpenSAFELY", email = "tech@opensafely.org"}]
 license = {file = "LICENSE"}
@@ -17,6 +16,7 @@ dependencies = [
   "pydantic",
   "ruamel.yaml",
 ]
+dynamic = ["version"]
 
 [project.urls]
 Home = "https://opensafely.org"
@@ -48,12 +48,6 @@ skip_covered = true
 
 [tool.coverage.html]
 
-[tool.flit.module]
-name = "pipeline"
-
-[tool.flit.sdist]
-exclude = ["pipeline/__main__.py"]
-
 [tool.isort]
 profile = "black"
 lines_after_imports = 2
@@ -72,3 +66,8 @@ warn_unreachable = true
 show_error_codes = true
 
 [tool.pytest.ini_options]
+
+[tool.setuptools.packages.find]
+include = ["pipeline*"]
+
+[tool.setuptools_scm]


### PR DESCRIPTION
This switches us from flit to setuptools as the build backend of the package, using setuptools-scm to pull the version from the latest git tag.

This will allow us to pin to a tag on GitHub and still get versioned packages with:

    pip install git+https://github.com/opensafely-core/pipeline@<a ref>

Both pyproject.toml and pip-tools support this method of installation (albeit in different formats).