### PR TITLE
fix: move to using ruyaml library instead of ruamel.yaml

### DIFF
--- a/pipeline/loading.py
+++ b/pipeline/loading.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Union
 
-from ruamel.yaml.error import (
+from ruyaml import YAML
+from ruyaml.error import (
     MarkedYAMLError,
     MarkedYAMLFutureWarning,
     MarkedYAMLWarning,
@@ -12,7 +13,6 @@ from ruamel.yaml.error import (
     YAMLStreamError,
     YAMLWarning,
 )
-from ruamel.yaml.main import YAML
 
 from . import exceptions
 
@@ -26,21 +26,21 @@ from . import exceptions
 # class is incorrect for this variable.  It's defined as Optional[Text] [1] but
 # the implementation accepts a list or string [2].
 #
-# 1: https://sourceforge.net/p/ruamel-yaml/code/ci/0.17.20/tree/main.py#l55
-# 2: https://sourceforge.net/p/ruamel-yaml/code/ci/0.17.20/tree/main.py#l66
+# 1: https://github.com/pycontribs/ruyaml/blob/main/lib/ruyaml/main.py#L70
+# 2: https://github.com/pycontribs/ruyaml/blob/main/lib/ruyaml/main.py#L81
 PARSER = YAML(typ=["safe", "rt"], pure=True)  # type: ignore[arg-type]
 
 
-RuamelMarkedError = Union[MarkedYAMLError, MarkedYAMLFutureWarning, MarkedYAMLWarning]
+RuyamlMarkedError = Union[MarkedYAMLError, MarkedYAMLFutureWarning, MarkedYAMLWarning]
 
 
 def make_yaml_error_more_helpful(
-    exc: RuamelMarkedError, name: str | None
-) -> RuamelMarkedError:
+    exc: RuyamlMarkedError, name: str | None
+) -> RuyamlMarkedError:
     """
     Improve the error message we expose when encountering errors.
 
-    ruamel produces quite helpful error messages but they refer to the file as
+    ruyaml produces quite helpful error messages but they refer to the file as
     `<byte_string>` (which will be confusing for users) and they also include
     notes and warnings to developers about API changes. This function attempts
     to fix these issues, but just returns the exception unchanged if the type
@@ -58,7 +58,7 @@ def make_yaml_error_more_helpful(
 def parse_yaml_file(data: str | Path, filename: str | None = None) -> dict[str, Any]:
     try:
         return PARSER.load(data)  # type: ignore[no-any-return]
-    # ruamel doesn't have a nice exception hierarchy so we have to catch these
+    # ruyaml doesn't have a nice exception hierarchy so we have to catch these
     # four separate base classes
     except (
         YAMLError,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
   "pydantic",
-  "ruamel.yaml",
+  "ruyaml",
 ]
 dynamic = ["version"]
 

--- a/requirements.prod.txt
+++ b/requirements.prod.txt
@@ -4,6 +4,10 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --output-file=requirements.prod.txt pyproject.toml
 #
+distro==1.8.0 \
+    --hash=sha256:02e111d1dc6a50abb8eed6bf31c3e48ed8b0830d1ea2a1b78c61765c2513fdd8 \
+    --hash=sha256:99522ca3e365cac527b44bde033f64c6945d90eb9f769703caaec52b09bbd3ff
+    # via ruyaml
 pydantic==1.9.0 \
     --hash=sha256:085ca1de245782e9b46cefcf99deecc67d418737a1fd3f6a4f511344b613a5b3 \
     --hash=sha256:086254884d10d3ba16da0588604ffdc5aab3f7f09557b998373e885c690dd398 \
@@ -41,38 +45,17 @@ pydantic==1.9.0 \
     --hash=sha256:f5a64b64ddf4c99fe201ac2724daada8595ada0d102ab96d019c1555c2d6441d \
     --hash=sha256:f947352c3434e8b937e3aa8f96f47bdfe6d92779e44bb3f41e4c213ba6a32145
     # via opensafely-pipeline (pyproject.toml)
-ruamel.yaml==0.17.21 \
-    --hash=sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7 \
-    --hash=sha256:8b7ce697a2f212752a35c1ac414471dc16c424c9573be4926b56ff3f5d23b7af
+ruyaml==0.91.0 \
+    --hash=sha256:50e0ee3389c77ad340e209472e0effd41ae0275246df00cdad0a067532171755 \
+    --hash=sha256:6ce9de9f4d082d696d3bde264664d1bcdca8f5a9dff9d1a1f1a127969ab871ab
     # via opensafely-pipeline (pyproject.toml)
-ruamel.yaml.clib==0.2.6 \
-    --hash=sha256:0847201b767447fc33b9c235780d3aa90357d20dd6108b92be544427bea197dd \
-    --hash=sha256:1070ba9dd7f9370d0513d649420c3b362ac2d687fe78c6e888f5b12bf8bc7bee \
-    --hash=sha256:1866cf2c284a03b9524a5cc00daca56d80057c5ce3cdc86a52020f4c720856f0 \
-    --hash=sha256:221eca6f35076c6ae472a531afa1c223b9c29377e62936f61bc8e6e8bdc5f9e7 \
-    --hash=sha256:31ea73e564a7b5fbbe8188ab8b334393e06d997914a4e184975348f204790277 \
-    --hash=sha256:3fb9575a5acd13031c57a62cc7823e5d2ff8bc3835ba4d94b921b4e6ee664104 \
-    --hash=sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd \
-    --hash=sha256:6e7be2c5bcb297f5b82fee9c665eb2eb7001d1050deaba8471842979293a80b0 \
-    --hash=sha256:72a2b8b2ff0a627496aad76f37a652bcef400fd861721744201ef1b45199ab78 \
-    --hash=sha256:77df077d32921ad46f34816a9a16e6356d8100374579bc35e15bab5d4e9377de \
-    --hash=sha256:78988ed190206672da0f5d50c61afef8f67daa718d614377dcd5e3ed85ab4a99 \
-    --hash=sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527 \
-    --hash=sha256:7f7ecb53ae6848f959db6ae93bdff1740e651809780822270eab111500842a84 \
-    --hash=sha256:825d5fccef6da42f3c8eccd4281af399f21c02b32d98e113dbc631ea6a6ecbc7 \
-    --hash=sha256:846fc8336443106fe23f9b6d6b8c14a53d38cef9a375149d61f99d78782ea468 \
-    --hash=sha256:89221ec6d6026f8ae859c09b9718799fea22c0e8da8b766b0b2c9a9ba2db326b \
-    --hash=sha256:9efef4aab5353387b07f6b22ace0867032b900d8e91674b5d8ea9150db5cae94 \
-    --hash=sha256:a32f8d81ea0c6173ab1b3da956869114cae53ba1e9f72374032e33ba3118c233 \
-    --hash=sha256:a49e0161897901d1ac9c4a79984b8410f450565bbad64dbfcbf76152743a0cdb \
-    --hash=sha256:ada3f400d9923a190ea8b59c8f60680c4ef8a4b0dfae134d2f2ff68429adfab5 \
-    --hash=sha256:bf75d28fa071645c529b5474a550a44686821decebdd00e21127ef1fd566eabe \
-    --hash=sha256:cfdb9389d888c5b74af297e51ce357b800dd844898af9d4a547ffc143fa56751 \
-    --hash=sha256:d67f273097c368265a7b81e152e07fb90ed395df6e552b9fa858c6d2c9f42502 \
-    --hash=sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed \
-    --hash=sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c
-    # via ruamel.yaml
 typing-extensions==4.1.1 \
     --hash=sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42 \
     --hash=sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2
     # via pydantic
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==67.1.0 \
+    --hash=sha256:a7687c12b444eaac951ea87a9627c4f904ac757e7abdc5aac32833234af90378 \
+    --hash=sha256:e261cdf010c11a41cb5cb5f1bf3338a7433832029f559a6a7614bd42a967c300
+    # via ruyaml

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -1,5 +1,5 @@
 import pytest
-from ruamel.yaml.error import YAMLStreamError
+from ruyaml.error import YAMLStreamError
 
 from pipeline import YAMLError
 from pipeline.loading import parse_yaml_file


### PR DESCRIPTION
ruamel.yaml is effectively abandoned, with a single antagonistic and
unresponsive maintainer.

ruyaml is a community maintained fork, that is a) maintained and b)
drops the annoying weird clib required dependency.

This makes it a nicer dependency to have in our stack.
