### PR TITLE
fix: wrap pydantic errors in ProjectValidationError

### DIFF
--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pydantic
+
 from .exceptions import ProjectValidationError, YAMLError
 from .loading import parse_yaml_file
 from .models import Pipeline
@@ -24,4 +26,9 @@ def load_pipeline(pipeline_config: str | Path, filename: str | None = None) -> P
         raise ProjectValidationError(*e.args)
 
     # validate
-    return Pipeline(**parsed_data)
+    try:
+        return Pipeline(**parsed_data)
+    except pydantic.ValidationError as exc:
+        raise ProjectValidationError(
+            f"Invalid project: {filename or ''}\n{exc}"
+        ) from exc

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import pydantic
 import pytest
 
 from pipeline import ProjectValidationError, load_pipeline
@@ -53,3 +54,17 @@ def test_load_pipeline_with_yaml_error_raises_projectvalidationerror():
     msg = 'found duplicate key "duplicate" with value "2"'
     with pytest.raises(ProjectValidationError, match=msg):
         load_pipeline(config)
+
+
+def test_load_pipeline_with_project_error_raises_projectvalidationerror():
+    """
+    Test load_pipeline() raises the expected exception
+    """
+    config = """
+        version: asdf
+    """
+
+    with pytest.raises(ProjectValidationError, match="Invalid project") as exc:
+        load_pipeline(config)
+
+    assert isinstance(exc.value.__cause__, pydantic.ValidationError)


### PR DESCRIPTION
This means we don't directly expose the underlying
pydantic.ValidationError.

However, its still available as exc.__cause__ if needed.
