### PR TITLE
Revert "chore: bump pydantic from 1.10.12 to 2.1.1"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "pydantic<3",
+  "pydantic<2",
   "ruyaml",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Reverts opensafely-core/pipeline#181

I don't know how we tell dependabot to not upgrade pyproject.toml when we're using it as a spec file… but we don't want this version bump yet.