### PR TITLE
Revert "chore: bump pydantic from 1.10.12 to 2.4.2"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "pydantic<3",
+  "pydantic<2",
   "ruyaml",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Reverts opensafely-core/pipeline#228