### PR TITLE
Revert "chore: bump pydantic from 1.10.12 to 2.5.1"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-  "pydantic<3",
+  "pydantic<2",
   "ruyaml",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
This reverts commit 4b04ffbf5ebe88886107f852fa94668b98bf5a8b.