### PR TITLE
Port job-runners requires_db logic

### DIFF
--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -20,22 +20,6 @@ from .validation import (
 cohortextractor_pat = re.compile(r"cohortextractor:\S+ generate_cohort")
 databuilder_pat = re.compile(r"databuilder|ehrql:\S+ generate[-_]dataset")
 
-database_action_pat = re.compile(
-    r"""
-    # image name
-    ^\b(?:cohortextractor|databuilder|ehrql)\b
-    # :<version> (v0, latest etc)
-    :.+
-    # command; for cohortextractor, only generate_cohort is a database action
-    # For ehrql (and legacy databuilder), generate-dataset and generate-measures
-    # are both database actions. Happily cohortextractor uses generate_measures as
-    # its measures command, so we can excluded cohortextractor measures
-    # actions with this regex.
-    \b(?:generate_cohort|generate-dataset|generate-measures)
-    """,
-    flags=re.X,
-)
-
 
 class Expectations(BaseModel):
     population_size: int
@@ -129,9 +113,35 @@ class Action(BaseModel):
 
         return Command(raw=run)
 
+    # orderd by most common,  going forwards
+    DB_COMMANDS = {
+        "ehrql": ("generate-dataset", "generate-measures"),
+        "sqlrunner": "*",  # all commands are valid
+        "cohortextractor": ("generate_cohort", "generate_codelist_report"),
+        "databuilder": ("generate-dataset",),
+    }
+
     @property
     def is_database_action(self) -> bool:
-        return database_action_pat.match(self.run.raw) is not None
+        """
+        By default actions do not have database access, but certain trusted actions require it
+        """
+        args = self.run.parts
+        image = args[0]
+        image = image.split(":")[0]
+        db_commands = self.DB_COMMANDS.get(image)
+        if db_commands is None:
+            return False
+
+        if db_commands == "*":
+            return True
+
+        # no command specified
+        if len(args) == 1:
+            return False
+
+        # 1st arg is command
+        return args[1] in db_commands
 
 
 class PartiallyValidatedPipeline(TypedDict):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -526,16 +526,6 @@ def test_pipeline_databuilder_recognizes_old_action_spelling():
     "name,run,is_database_action",
     [
         (
-            "generate_cohort",
-            "cohortextractor:latest generate_cohort args --option",
-            True,
-        ),
-        (
-            "generate_databuilder_dataset",
-            "databuilder:v0 generate-dataset args --output=output/input.csv",
-            True,
-        ),
-        (
             "generate_ehrql_dataset",
             "ehrql:v0 generate-dataset args --output=output/input.csv",
             True,
@@ -547,6 +537,21 @@ def test_pipeline_databuilder_recognizes_old_action_spelling():
         ),
         ("generate_ehrql_measures", "ehrql:v0 generate-measures args --option", True),
         (
+            "sqlrunner",
+            "sqlrunner:v1 foo -output=output/input.csv",
+            True,
+        ),
+        (
+            "generate_cohort",
+            "cohortextractor:latest generate_cohort args --option",
+            True,
+        ),
+        (
+            "generate_databuilder_dataset",
+            "databuilder:v0 generate-dataset args --output=output/input.csv",
+            True,
+        ),
+        (
             "generate_cohortextractor_measures",
             "cohortextractor:latest generate_measures args --option",
             False,
@@ -556,6 +561,7 @@ def test_pipeline_databuilder_recognizes_old_action_spelling():
             "python:latest generate-measures.py args --option",
             False,
         ),
+        ("no_command", "ehrql:v1", False),
     ],
 )
 def test_action_is_database_action(name, run, is_database_action):


### PR DESCRIPTION
This is more robust implementation that the current regex, and also adds
support for sqlrunner being correctly detected.

First part of #250
