### PR TITLE
Expose is_database_action logic as function

### DIFF
--- a/pipeline/__main__.py
+++ b/pipeline/__main__.py
@@ -1,6 +1,7 @@
 """
 This module is for testing in local development.
 """
+
 import sys
 
 from devtools import debug

--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -20,6 +20,35 @@ from .validation import (
 cohortextractor_pat = re.compile(r"cohortextractor:\S+ generate_cohort")
 databuilder_pat = re.compile(r"databuilder|ehrql:\S+ generate[-_]dataset")
 
+# orderd by most common, going forwards
+DB_COMMANDS = {
+    "ehrql": ("generate-dataset", "generate-measures"),
+    "sqlrunner": "*",  # all commands are valid
+    "cohortextractor": ("generate_cohort", "generate_codelist_report"),
+    "databuilder": ("generate-dataset",),
+}
+
+
+def is_database_action(args: List[str]) -> bool:
+    """
+    By default actions do not have database access, but certain trusted actions require it
+    """
+    image = args[0]
+    image = image.split(":")[0]
+    db_commands = DB_COMMANDS.get(image)
+    if db_commands is None:
+        return False
+
+    if db_commands == "*":
+        return True
+
+    # no command specified
+    if len(args) == 1:
+        return False
+
+    # 1st arg is command
+    return args[1] in db_commands
+
 
 class Expectations(BaseModel):
     population_size: int
@@ -113,35 +142,9 @@ class Action(BaseModel):
 
         return Command(raw=run)
 
-    # orderd by most common,  going forwards
-    DB_COMMANDS = {
-        "ehrql": ("generate-dataset", "generate-measures"),
-        "sqlrunner": "*",  # all commands are valid
-        "cohortextractor": ("generate_cohort", "generate_codelist_report"),
-        "databuilder": ("generate-dataset",),
-    }
-
     @property
     def is_database_action(self) -> bool:
-        """
-        By default actions do not have database access, but certain trusted actions require it
-        """
-        args = self.run.parts
-        image = args[0]
-        image = image.split(":")[0]
-        db_commands = self.DB_COMMANDS.get(image)
-        if db_commands is None:
-            return False
-
-        if db_commands == "*":
-            return True
-
-        # no command specified
-        if len(args) == 1:
-            return False
-
-        # 1st arg is command
-        return args[1] in db_commands
+        return is_database_action(self.run.parts)
 
 
 class PartiallyValidatedPipeline(TypedDict):

--- a/pipeline/types.py
+++ b/pipeline/types.py
@@ -5,6 +5,7 @@ When loading data from YAML we get dictionaries which pydantic attempts to
 validate.  Some of our validation is done via custom methods using the raw
 dictionary data.
 """
+
 from __future__ import annotations
 
 import pathlib


### PR DESCRIPTION
When running reusable actions, which are *not* parsed by a Pipeline or
similar model atm, we need to detect whether a job is a db job (as
reusable actions are *not* allowed to be db jobs).

This change allows us to easily re-use the logic from outside of
a Pipeline model context.

Includes random black fixes for some reason :shrug:
