### PR TITLE
Remove PDF from allowed L4 file types

### DIFF
--- a/pipeline/constants.py
+++ b/pipeline/constants.py
@@ -13,7 +13,6 @@ LEVEL4_FILE_TYPES = set(
         ".svgz",
         # reports
         ".html",
-        ".pdf",
         ".txt",
         ".log",
         ".json",

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -21,6 +21,7 @@ def test_assert_valid_glob_pattern():
         ("outputs/*", "highly_sensitive"),
         ("outputs/foo.*", "highly_sensitive"),
         ("outputs/output.rds", "moderately_sensitive"),
+        ("outputs/output.pdf", "moderately_sensitive"),
     ]
     for pattern, sensitivity in bad_patterns:
         with pytest.raises(InvalidPatternError):


### PR DESCRIPTION
[Confirmed by](https://bennettoxford.slack.com/archives/C069YDR4NCA/p1721381925174499?thread_ts=1721381259.803759&cid=C069YDR4NCA) Louis that PDFs should not be allowed on L4 or for releasing