### PR TITLE
Apply fixes from interactive-templates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,11 +68,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Tag new release
         run: |
           # ignore failures here to avoid merges into main without version
           # bumps failing this job.
-          git tag "v$(cat version)" || exit
+          git tag "v$(cat version)" || exit 0
           git push --tags
 
   required-checks:


### PR DESCRIPTION
These changes ensure that we:

* don't end up tagging a commit with the same tag as might already exist (because the tag may exist, but we don't necessarily pull that without `fetch-depth: 0`)
* correctly exit without error if the tag already exists

This prevents every merge without a new version resulting in a failure for this workflow job.

See:

* opensafely-core/interactive-templates@89e4776a5b30ff626a38509eeb4b451fd6cc4fa1
* opensafely-core/interactive-templates@679c0382520217d7fda1944a2c455e7a6c42a270