### PR TITLE
Raise ValidationError for empty or incomplete action configs

### DIFF
--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -11,6 +11,7 @@ from .constants import RUN_ALL_COMMAND
 from .exceptions import InvalidPatternError, ValidationError
 from .features import LATEST_VERSION, get_feature_flags_for_version
 from .validation import (
+    validate_action_config,
     validate_cohortextractor_outputs,
     validate_databuilder_outputs,
     validate_glob_pattern,
@@ -266,10 +267,12 @@ class Pipeline:
         feat = get_feature_flags_for_version(version)
 
         validate_type(actions, dict, "Project `actions` section")
-        actions = {
-            action_id: Action.build(action_id, **action_config)
-            for action_id, action_config in actions.items()
-        }
+
+        _actions = dict()
+        for action_id, action_config in actions.items():
+            validate_action_config(action_id, action_config)
+            _actions[action_id] = Action.build(action_id, **action_config)
+        actions = _actions
 
         if feat.REMOVE_SUPPORT_FOR_COHORT_EXTRACTOR:
             for config in actions.values():

--- a/pipeline/validation.py
+++ b/pipeline/validation.py
@@ -79,6 +79,16 @@ def validate_glob_pattern(pattern: str, privacy_level: str) -> None:
         raise InvalidPatternError("is an absolute path")
 
 
+def validate_action_config(action_id: str, action_config: Any) -> None:
+    # Verifies the required arguments for Action.build are present
+    validate_type(action_config, dict, f"Configuration for action {action_id}")
+    for key in ["run", "outputs"]:
+        if key not in action_config:
+            raise ValidationError(
+                f"Action {action_id} must contain a configuration for '{key}'"
+            )
+
+
 def validate_not_cohort_extractor_action(action: Action) -> None:
     if action.run.parts[0].startswith("cohortextractor"):
         raise ValidationError(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -356,6 +356,22 @@ def test_pipeline_with_duplicated_action_run_commands():
         Pipeline.build(**data)
 
 
+@pytest.mark.parametrize(
+    "action_value,match",
+    [
+        (None, "Configuration for action action1 must be a dictionary"),
+        ({}, "Action action1 must contain a configuration for 'run'"),
+    ],
+)
+def test_pipeline_with_empty_action(action_value, match):
+    data = {
+        "version": 1,
+        "actions": {"action1": action_value},
+    }
+    with pytest.raises(ValidationError, match=match):
+        Pipeline.build(**data)
+
+
 def test_pipeline_with_empty_run_command():
     data = {
         "version": 1,
@@ -370,6 +386,19 @@ def test_pipeline_with_empty_run_command():
     }
 
     match = "run must have a value, action1 has an empty run key"
+    with pytest.raises(ValidationError, match=match):
+        Pipeline.build(**data)
+
+
+def test_pipeline_without_specifying_output_for_action():
+    data = {
+        "version": 1,
+        "actions": {
+            "action1": {"run": "test"},
+        },
+    }
+
+    match = "Action action1 must contain a configuration for 'outputs'"
     with pytest.raises(ValidationError, match=match):
         Pipeline.build(**data)
 


### PR DESCRIPTION
Part of #344. Necessary due to the [noactions.yaml](https://github.com/opensafely-core/opensafely-cli/blob/main/tests/fixtures/projects/noactions.yaml) fixture in `opensafely-cli` that tests for this.

- Validates that actions in `project.yaml` contain both `run` and `output` keys, i.e. the necessary arguments for `Actions.build` to be called.
- Further validations can be handled within `Actions.build()`. 