### PR TITLE
Add Pipeline.action_images property

### DIFF
--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -344,3 +344,19 @@ class Pipeline:
         than set operators as previously so we preserve the original order.
         """
         return [action for action in self.actions.keys() if action != RUN_ALL_COMMAND]
+
+    @property
+    def action_images(self) -> set[str]:
+        """
+        Get all unique action images/version used in this project.
+
+        This is useful for tooling to know which image version to support.
+        """
+        images = set()
+        for action in self.actions.values():
+            # for hysterical raisins, :latest is actually mapped to v1, not v2 or later.
+            # We hope to fix this at some point
+            version = "v1" if action.run.version == "latest" else action.run.version
+            images.add(f"{action.run.name}:{version}")
+
+        return images

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -678,3 +678,38 @@ def test_action_is_database_action(name, run, is_database_action):
 
     action = Pipeline.build(**data).actions[name]
     assert action.is_database_action == is_database_action
+
+
+def test_action_images():
+    data = {
+        "version": 1,
+        "actions": {
+            "ehrql": {
+                "run": "ehrql:v1 ...",
+                "outputs": {
+                    "highly_sensitive": {"cohort": "output/input.csv"},
+                },
+            },
+            "r1": {
+                "run": "r:latest 1",
+                "outputs": {
+                    "highly_sensitive": {"cohort": "output/input.csv"},
+                },
+            },
+            "r2": {
+                "run": "r:latest 2",
+                "outputs": {
+                    "highly_sensitive": {"cohort": "output/input.csv"},
+                },
+            },
+            "python": {
+                "run": "python:v2 ...",
+                "outputs": {
+                    "highly_sensitive": {"cohort": "output/input.csv"},
+                },
+            },
+        },
+    }
+
+    pipeline = Pipeline.build(**data)
+    assert pipeline.action_images == set(["ehrql:v1", "r:v1", "python:v2"])


### PR DESCRIPTION
This is useful downstream in tooling, for `opensafely pull` and codespaces support.

Also, encoding that latest == v1 in one central place will make it easier to change that value when we change that in future.