### PR TITLE
Add clarification to 'expectations' error message

### DIFF
--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -331,7 +331,8 @@ class Pipeline:
         if feat.REMOVE_SUPPORT_FOR_COHORT_EXTRACTOR:
             if expectations is not None:
                 raise ValidationError(
-                    "Project includes `expectations` section, which is not supported in this version"
+                    "Project includes `expectations` section, which is not supported in this version. "
+                    "This section is only applicable to deprecated cohortextractor actions; you can safely remove it."
                 )
         elif feat.EXPECTATIONS_POPULATION:
             if expectations is None:


### PR DESCRIPTION
From project.yaml v4, the "expectations" section is no longer valid. It was only used for cohort-extractor, and v4 was part of the work to deprecate cohort-extractor.

Recently we added a check for the version of project.yaml being used, and we prompt users to update it if they're on an old version. Although it's been a while since cohort-extractor was a thing, users may be using project.yamls that they've copied/pasted from other projects, which are still on <=v3, and which will error when they upgrade, because they'll still have an "expectations" section. It's not obvious to users that that expectations section is ignored and only applied to old cohort-extractor actions, and that they can safely remove it without breaking their project, so let's tell them that in the error message.