### PR TITLE
Allow action images tagged vN-pre

### DIFF
--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -219,7 +219,7 @@ class Action:
 
     # Valid image versions. `dev` is for local testing
     # Note: at some point, we probably want to disallow latest.
-    VERSION_REGEX = re.compile(r"^((v[\d.]+)|dev|latest)$")
+    VERSION_REGEX = re.compile(r"^((v[\d.]+(-pre)?)|dev|latest)$")
 
     @classmethod
     def parse_run_string(cls, action_id: str, run: str) -> Command:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -32,6 +32,7 @@ def test_success():
         "test:other",
         "test:vnotdigits",
         "test:v1x1",
+        "test:pre",
     ],
 )
 def test_action_handles_invalid_version(action):
@@ -61,6 +62,8 @@ def test_action_handles_invalid_version(action):
         "test:v1.2.3",
         "test:dev",
         "test:latest",
+        "test:v1-pre",
+        "test:v1.2-pre",
     ],
 )
 def test_action_handles_valid_version(action):


### PR DESCRIPTION
We intend to use tags such as r:v3-pre to publish pre-release action images for testing purposes.