### PR TITLE
Drop 3.8 and 3.9 CI checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
   check:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-22.04
 
@@ -30,7 +30,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-22.04
 
@@ -50,7 +50,7 @@ jobs:
   test-fastparser:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-22.04
 
@@ -70,7 +70,7 @@ jobs:
   test-package-build:
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
In advance of dropping support for python <3.10; this means the 3.8 amd 3.9 checks won't be required for the upgrade PR (they're currently preventing it from being mergable)