### PR TITLE
persist-credentials is required for pushing new tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          persist-credentials: false
+          persist-credentials: true # persist credentials is required for the tag/push
       - name: Tag new release
         run: |
           # ignore failures here to avoid merges into main without version


### PR DESCRIPTION
We set persist-credentials to false wherever possible, but this is one of the cases where it is required.