### PR TITLE
Introduce a minimum version, in advance of enforcing v5

### DIFF
--- a/justfile
+++ b/justfile
@@ -61,7 +61,7 @@ install-fastparser: devenv
 
 # Run the tests
 test python-version="$(cat .python-version)" extra="" *args="":
-    uv run --python {{ python-version }} {{ extra }} coverage run --module pytest
+    uv run --python {{ python-version }} {{ extra }} coverage run --module pytest {{ args }}
     uv run --python {{ python-version }} {{ extra }} coverage report || $BIN/coverage html
 
 test-with-fastparser python-version="$(cat .python-version)":

--- a/pipeline/features.py
+++ b/pipeline/features.py
@@ -15,6 +15,8 @@ FEATURE_FLAGS_BY_VERSION = {
 
 LATEST_VERSION = max([v[0] for v in FEATURE_FLAGS_BY_VERSION.values()])
 
+MINIMUM_VERSION = 4
+
 
 def get_feature_flags_for_version(version: float) -> SimpleNamespace:
     if version > LATEST_VERSION:

--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from .constants import RUN_ALL_COMMAND
 from .exceptions import InvalidPatternError, ValidationError
-from .features import LATEST_VERSION, get_feature_flags_for_version
+from .features import LATEST_VERSION, MINIMUM_VERSION, get_feature_flags_for_version
 from .validation import (
     validate_action_config,
     validate_actions_config,
@@ -272,9 +272,13 @@ class Pipeline:
             version = float(version)
         except (TypeError, ValueError):
             raise ValidationError(
-                f"`version` must be a number between 1 and {LATEST_VERSION}"
+                f"`version` must be a number between {MINIMUM_VERSION} and {LATEST_VERSION}"
             )
         else:
+            if version < MINIMUM_VERSION:
+                raise ValidationError(
+                    f"Your project file is using a deprecated version ({version}); update to at least version {MINIMUM_VERSION}"
+                )
             if version != LATEST_VERSION:
                 warnings.warn(
                     f"ProjectWarning: Your project file is using an old version ({version}); consider updating to version {LATEST_VERSION}",

--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -13,7 +13,6 @@ from .features import LATEST_VERSION, MINIMUM_VERSION, get_feature_flags_for_ver
 from .validation import (
     validate_action_config,
     validate_actions_config,
-    validate_cohortextractor_outputs,
     validate_ehrql_outputs,
     validate_glob_pattern,
     validate_no_kwargs,
@@ -29,7 +28,6 @@ from .validation import (
 DB_COMMANDS = {
     "ehrql": ("generate-dataset", "generate-measures"),
     "sqlrunner": "*",  # all commands are valid
-    "cohortextractor": ("generate_cohort", "generate_codelist_report"),
     "databuilder": ("generate-dataset",),
 }
 
@@ -191,8 +189,6 @@ class Action:
                 )
         action = cls(action_id, outputs, run, needs, config, dummy_data_file)
 
-        if re.match(r"cohortextractor:\S+ generate_cohort", run.raw):
-            validate_cohortextractor_outputs(action_id, action)
         if re.match(r"(ehrql|databuilder):\S+ generate[-_]dataset", run.raw):
             validate_ehrql_outputs(action_id, action)
 
@@ -274,9 +270,8 @@ class Pipeline:
             _actions[action_id] = Action.build(action_id, **action_config)
         actions = _actions
 
-        if feat.REMOVE_SUPPORT_FOR_COHORT_EXTRACTOR:
-            for config in actions.values():
-                validate_not_cohort_extractor_action(config)
+        for config in actions.values():
+            validate_not_cohort_extractor_action(config)
 
         if feat.REMOVE_SUPPORT_FOR_LATEST_TAG:
             for config in actions.values():
@@ -284,8 +279,7 @@ class Pipeline:
 
         validate_actions_config(actions)
 
-        if feat.UNIQUE_OUTPUT_PATH:
-            validate_unique_output_paths(actions)
+        validate_unique_output_paths(actions)
 
         return cls(version, actions)
 

--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -4,7 +4,6 @@ import pathlib
 import re
 import shlex
 import warnings
-from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any
 
@@ -13,6 +12,7 @@ from .exceptions import InvalidPatternError, ValidationError
 from .features import LATEST_VERSION, get_feature_flags_for_version
 from .validation import (
     validate_action_config,
+    validate_actions_config,
     validate_cohortextractor_outputs,
     validate_ehrql_outputs,
     validate_glob_pattern,
@@ -21,6 +21,7 @@ from .validation import (
     validate_not_latest_tag,
     validate_not_run_all_action,
     validate_type,
+    validate_unique_output_paths,
 )
 
 
@@ -299,34 +300,10 @@ class Pipeline:
             for config in actions.values():
                 validate_not_latest_tag(config)
 
-        seen: dict[Command, list[str]] = defaultdict(list)
-        for name, config in actions.items():
-            run = config.run
-            if run in seen:
-                raise ValidationError(
-                    f"Action {name} has the same 'run' command as other actions: {' ,'.join(seen[run])}"
-                )
-            seen[run].append(name)
+        validate_actions_config(actions)
 
         if feat.UNIQUE_OUTPUT_PATH:
-            # find duplicate paths defined in the outputs section
-            seen_files = []
-            for config in actions.values():
-                for output in config.outputs.dict().values():
-                    for filename in output.values():
-                        if filename in seen_files:
-                            raise ValidationError(
-                                f"Output path {filename} is not unique"
-                            )
-
-                        seen_files.append(filename)
-
-        for a in actions.values():
-            for n in a.needs:
-                if n not in actions:
-                    raise ValidationError(
-                        f"Action `{a.action_id}` references an unknown action in its `needs` list: {n}"
-                    )
+            validate_unique_output_paths(actions)
 
         if feat.REMOVE_SUPPORT_FOR_COHORT_EXTRACTOR:
             if expectations is not None:

--- a/pipeline/models.py
+++ b/pipeline/models.py
@@ -56,26 +56,6 @@ def is_database_action(args: list[str]) -> bool:
 
 
 @dataclass(frozen=True)
-class Expectations:
-    population_size: int
-
-    @classmethod
-    def build(
-        cls,
-        population_size: Any = None,
-        **kwargs: Any,
-    ) -> Expectations:
-        validate_no_kwargs(kwargs, "project `expectations` section")
-        try:
-            population_size = int(population_size)
-        except (TypeError, ValueError):
-            raise ValidationError(
-                "Project expectations population size must be a number",
-            )
-        return cls(population_size)
-
-
-@dataclass(frozen=True)
 class Outputs:
     highly_sensitive: dict[str, str] | None
     moderately_sensitive: dict[str, str] | None
@@ -250,14 +230,12 @@ class Action:
 class Pipeline:
     version: float
     actions: dict[str, Action]
-    expectations: Expectations | None
 
     @classmethod
     def build(
         cls,
         version: Any = None,
         actions: Any = None,
-        expectations: Any = None,
         **kwargs: Any,
     ) -> Pipeline:
         validate_no_kwargs(kwargs, "project")
@@ -309,27 +287,7 @@ class Pipeline:
         if feat.UNIQUE_OUTPUT_PATH:
             validate_unique_output_paths(actions)
 
-        if feat.REMOVE_SUPPORT_FOR_COHORT_EXTRACTOR:
-            if expectations is not None:
-                raise ValidationError(
-                    "Project includes `expectations` section, which is not supported in this version. "
-                    "This section is only applicable to deprecated cohortextractor actions; you can safely remove it."
-                )
-        elif feat.EXPECTATIONS_POPULATION:
-            if expectations is None:
-                raise ValidationError("Project must include `expectations` section")
-        else:
-            expectations = {"population_size": 1000}
-
-        if expectations is not None:
-            validate_type(expectations, dict, "Project `expectations` section")
-            if "population_size" not in expectations:
-                raise ValidationError(
-                    "Project `expectations` section must include `population_size` section",
-                )
-            expectations = Expectations.build(**expectations)
-
-        return cls(version, actions, expectations)
+        return cls(version, actions)
 
     @property
     def all_actions(self) -> list[str]:

--- a/pipeline/validation.py
+++ b/pipeline/validation.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import fnmatch
 import posixpath
 import warnings
+from collections import defaultdict
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
@@ -13,7 +14,7 @@ from .outputs import get_output_dirs
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .models import Action
+    from .models import Action, Command
 
 
 def validate_type(val: Any, exp_type: type, loc: str, optional: bool = False) -> None:
@@ -92,6 +93,29 @@ def validate_action_config(action_id: str, action_config: Any) -> None:
             )
 
 
+def validate_actions_config(actions: dict[str, Action]) -> None:
+    """
+    Validates that actions are consistent and valid with respect to other actions
+    - run commands are not duplicated
+    - Specified `needs` are valid actions
+    """
+    seen: dict[Command, list[str]] = defaultdict(list)
+    for name, config in actions.items():
+        run = config.run
+        if run in seen:
+            raise ValidationError(
+                f"Action {name} has the same 'run' command as other actions: {' ,'.join(seen[run])}"
+            )
+        seen[run].append(name)
+
+    for a in actions.values():
+        for n in a.needs:
+            if n not in actions:
+                raise ValidationError(
+                    f"Action `{a.action_id}` references an unknown action in its `needs` list: {n}"
+                )
+
+
 def validate_not_cohort_extractor_action(action: Action) -> None:
     if action.run.parts[0].startswith("cohortextractor"):
         raise ValidationError(
@@ -119,6 +143,20 @@ def validate_not_latest_tag(action: Action) -> None:
         raise ValidationError(
             f"Action {action.action_id} uses `{action.run.parts[0]}`, which is not supported. Provide a version e.g. `:v2` instead"
         )
+
+
+def validate_unique_output_paths(actions: dict[str, Action]) -> None:
+    """
+    Validates that paths defined in the outputs section are unique
+    """
+    seen_files = []
+    for config in actions.values():
+        for output in config.outputs.dict().values():
+            for filename in output.values():
+                if filename in seen_files:
+                    raise ValidationError(f"Output path {filename} is not unique")
+
+                seen_files.append(filename)
 
 
 def validate_cohortextractor_outputs(action_id: str, action: Action) -> None:

--- a/pipeline/validation.py
+++ b/pipeline/validation.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, Any
 
 from .constants import LEVEL4_FILE_TYPES
 from .exceptions import InvalidPatternError, ValidationError
-from .outputs import get_output_dirs
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -157,41 +156,6 @@ def validate_unique_output_paths(actions: dict[str, Action]) -> None:
                     raise ValidationError(f"Output path {filename} is not unique")
 
                 seen_files.append(filename)
-
-
-def validate_cohortextractor_outputs(action_id: str, action: Action) -> None:
-    """
-    Check cohortextractor's output config is valid for this command
-
-    We can't validate outputs in the Action or Outputs models because we need
-    to look up other fields (eg run).
-    """
-    # ensure we only have output level defined.
-    num_output_levels = len(action.outputs)
-    if num_output_levels != 1:
-        raise ValidationError(
-            "A `generate_cohort` action must have exactly one output; "
-            f"{action_id} had {num_output_levels}"
-        )
-
-    output_dirs = get_output_dirs(action.outputs)
-    if len(output_dirs) == 1:
-        return
-
-    # If we detect multiple output directories but the command explicitly
-    # specifies an output directory then we assume the user knows what
-    # they're doing and don't attempt to modify the output directory or
-    # throw an error
-    flag = "--output-dir"
-    has_output_dir = any(
-        arg == flag or arg.startswith(f"{flag}=") for arg in action.run.parts
-    )
-    if not has_output_dir:
-        raise ValidationError(
-            f"generate_cohort command should produce output in only one "
-            f"directory, found {len(output_dirs)}:\n"
-            + "\n".join([f" - {d}/" for d in output_dirs])
-        )
 
 
 def validate_ehrql_outputs(action_id: str, action: Action) -> None:

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -9,7 +9,7 @@ def test_get_all_output_patterns_from_project_file_success():
         run: python:latest python analyse1.py
         outputs:
           moderately_sensitive:
-            cohort: output/input.csv
+            output: output/input.csv
             other: output/graph_*.png
 
       second:

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -3,7 +3,7 @@ from pipeline.legacy import get_all_output_patterns_from_project_file
 
 def test_get_all_output_patterns_from_project_file_success():
     config = """
-    version: 1
+    version: 4
     actions:
       first:
         run: python:latest python analyse1.py

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,7 +16,7 @@ def test_load_pipeline_with_path(mocker, tmp_path):
         "actions": {
             "first": {
                 "run": "python:latest python foo.py",
-                "outputs": {"highly_sensitive": {"cohort": "output/cohort.csv"}},
+                "outputs": {"highly_sensitive": {"result": "output/result.csv"}},
             }
         },
     }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,7 @@ def test_load_pipeline_with_file(test_file):
 
 def test_load_pipeline_with_path(mocker, tmp_path):
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "first": {
                 "run": "python:latest python foo.py",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -310,90 +310,6 @@ def test_command_properties():
     assert action.run.version == "latest"
 
 
-def test_expectations_before_v3_has_a_default_set():
-    data = {
-        "version": 2,
-        "expectations": {},
-        "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
-                "outputs": {"highly_sensitive": {"cohort": "output/input.csv"}},
-            }
-        },
-    }
-
-    config = Pipeline.build(**data)
-
-    assert config.expectations.population_size == 1000
-
-
-def test_expectations_does_not_exist_after_v3():
-    data = {
-        "version": 4,
-        "expectations": {},
-        "actions": {
-            "generate_dataset": {
-                "run": "ehrql:v1 generate-dataset args --output output/dataset.csv.gz",
-                "outputs": {"highly_sensitive": {"dataset": "output/dataset.csv.gz"}},
-            }
-        },
-    }
-    msg = "Project includes `expectations` section"
-    with pytest.raises(ValidationError, match=msg):
-        Pipeline.build(**data)
-
-
-def test_expectations_exists_for_v3():
-    # our logic for this is custom so ensure it works as expected
-    data = {
-        "version": 3,
-        "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
-                "outputs": {"highly_sensitive": {"cohort": "output/input.csv"}},
-            }
-        },
-    }
-
-    msg = "Project must include `expectations` section"
-    with pytest.raises(ValidationError, match=msg):
-        Pipeline.build(**data)
-
-
-def test_expectations_population_size_exists_for_v3():
-    data = {
-        "version": 3,
-        "expectations": {},
-        "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
-                "outputs": {"highly_sensitive": {"cohort": "output/input.csv"}},
-            }
-        },
-    }
-
-    msg = "Project `expectations` section must include `population_size` section"
-    with pytest.raises(ValidationError, match=msg):
-        Pipeline.build(**data)
-
-
-def test_expectations_population_size_is_a_number_for_v3():
-    data = {
-        "version": 3,
-        "expectations": {"population_size": "test"},
-        "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
-                "outputs": {"highly_sensitive": {"cohort": "output/input.csv"}},
-            }
-        },
-    }
-
-    msg = "Project expectations population size must be a number"
-    with pytest.raises(ValidationError, match=msg):
-        Pipeline.build(**data)
-
-
 def test_pipeline_all_actions(test_file):
     # load the pipeline fixture for simplicity here
     config = load_pipeline(test_file)
@@ -547,7 +463,6 @@ def test_pipeline_without_specifying_output_for_action():
 
 def test_pipeline_with_missing_or_none_version():
     data = {
-        "expectations": {"population_size": 10},
         "actions": {
             "action1": {
                 "run": "test",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -157,8 +157,8 @@ def test_action_extraction_command_with_one_outputs():
 
     config = Pipeline.build(**data)
 
-    outputs = config.actions["generate_output"].outputs.dict()
-    assert len(outputs.values()) == 1
+    outputs = config.actions["generate_output"].outputs
+    assert len(outputs) == 1
 
 
 def test_action_ehrql_with_multiple_output_files():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,6 +4,7 @@ import pytest
 
 from pipeline import load_pipeline
 from pipeline.exceptions import ValidationError
+from pipeline.features import LATEST_VERSION, MINIMUM_VERSION
 from pipeline.models import Outputs, Pipeline
 
 
@@ -37,7 +38,7 @@ def test_success():
 )
 def test_action_handles_invalid_version(action):
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "generate_cohort": {
                 "run": action,
@@ -68,7 +69,7 @@ def test_action_handles_invalid_version(action):
 )
 def test_action_handles_valid_version(action):
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "generate_cohort": {
                 "run": action,
@@ -163,7 +164,7 @@ def test_action_extraction_command_with_less_than_highly_sensitive_output(
     image, sensitivity
 ):
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "generate_cohort": {
                 "run": f"{image}:latest generate-dataset",
@@ -215,7 +216,7 @@ def test_action_ehrql_with_no_output_file():
 
 def test_action_extraction_command_with_one_outputs():
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "generate_cohort": {
                 "run": "cohortextractor:latest generate_cohort",
@@ -289,7 +290,7 @@ def test_cohortextractor_actions_not_used_after_v3():
 
 def test_command_properties():
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "generate_cohort": {
                 "run": "cohortextractor:latest generate_cohort another_arg",
@@ -410,7 +411,7 @@ def test_pipeline_all_actions(test_file):
 
 def test_pipeline_needs_success():
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "generate_cohort": {
                 "run": "cohortextractor:latest generate_cohort",
@@ -431,7 +432,7 @@ def test_pipeline_needs_success():
 
 def test_pipeline_needs_with_non_comma_delimited_actions():
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "generate_cohort": {
                 "run": "cohortextractor:latest generate_cohort",
@@ -456,7 +457,7 @@ def test_pipeline_needs_with_non_comma_delimited_actions():
 
 def test_pipeline_needs_with_unknown_action():
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "action1": {
                 "run": "test:latest",
@@ -475,7 +476,7 @@ def test_pipeline_needs_with_unknown_action():
 
 def test_pipeline_with_duplicated_action_run_commands():
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "action1": {
                 "run": "test:latest",
@@ -506,7 +507,7 @@ def test_pipeline_with_duplicated_action_run_commands():
 )
 def test_pipeline_with_empty_action(action_value, match):
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {"action1": action_value},
     }
     with pytest.raises(ValidationError, match=match):
@@ -515,7 +516,7 @@ def test_pipeline_with_empty_action(action_value, match):
 
 def test_pipeline_with_empty_run_command():
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "action1": {
                 "run": "",
@@ -533,7 +534,7 @@ def test_pipeline_with_empty_run_command():
 
 def test_pipeline_without_specifying_output_for_action():
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "action1": {"run": "test"},
         },
@@ -575,7 +576,7 @@ def test_pipeline_with_non_numeric_version():
         },
     }
 
-    msg = "`version` must be a number between 1 and"
+    msg = f"`version` must be a number between {MINIMUM_VERSION} and {LATEST_VERSION}"
 
     with pytest.raises(ValidationError, match=msg):
         data["version"] = "test"
@@ -584,7 +585,7 @@ def test_pipeline_with_non_numeric_version():
 
 def test_outputs_files_are_unique():
     data = {
-        "version": 2,
+        "version": 4,
         "actions": {
             "generate_cohort": {
                 "run": "cohortextractor:latest generate_cohort",
@@ -634,7 +635,7 @@ def test_outputs_with_unknown_privacy_level():
         # no outputs
         Pipeline.build(
             **{
-                "version": 1,
+                "version": 4,
                 "actions": {
                     "action1": {
                         "run": "test",
@@ -647,7 +648,7 @@ def test_outputs_with_unknown_privacy_level():
     with pytest.raises(ValidationError, match=msg):
         Pipeline.build(
             **{
-                "version": 1,
+                "version": 4,
                 "actions": {
                     "action1": {
                         "run": "test",
@@ -660,7 +661,7 @@ def test_outputs_with_unknown_privacy_level():
 
 def test_outputs_with_invalid_pattern():
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "generate_cohort": {
                 "run": "cohortextractor:latest generate_cohort",
@@ -677,7 +678,7 @@ def test_outputs_with_invalid_pattern():
 @pytest.mark.parametrize("image,tag", [("databuilder", "latest"), ("ehrql", "v1")])
 def test_pipeline_ehrql_specifies_same_output(image, tag):
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "generate-dataset": {
                 "run": f"{image}:{tag} generate-dataset --output=output/dataset.csv",
@@ -692,7 +693,7 @@ def test_pipeline_ehrql_specifies_same_output(image, tag):
 @pytest.mark.parametrize("image,tag", [("databuilder", "latest"), ("ehrql", "v1")])
 def test_pipeline_ehrql_specifies_different_output(image, tag):
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "generate-dataset": {
                 "run": f"{image}:{tag} generate-dataset --output=output/dataset1.csv",
@@ -710,7 +711,7 @@ def test_pipeline_databuilder_recognizes_old_action_spelling():
     # The action name is used to select the validator, so the only way to know that it's been recognized is
     # to give it an invalid input and check that validation fails.
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             "old-spelling": {
                 "run": "databuilder:latest generate_dataset --output=output/dataset1.csv",
@@ -767,7 +768,7 @@ def test_pipeline_databuilder_recognizes_old_action_spelling():
 )
 def test_action_is_database_action(name, run, is_database_action):
     data = {
-        "version": 1,
+        "version": 4,
         "actions": {
             name: {
                 "run": run,
@@ -906,6 +907,22 @@ def test_warning_for_old_version():
     with pytest.warns(UserWarning, match="project file is using an old version"):
         Pipeline.build(
             version=4,
+            actions={
+                "my_action": {
+                    "outputs": {"highly_sensitive": {"foo": "bar.txt"}},
+                    "run": "test:v1",
+                }
+            },
+        )
+
+
+@pytest.mark.parametrize("version", list(range(1, MINIMUM_VERSION)))
+def test_deprecated_version(version):
+    with pytest.raises(
+        ValidationError, match="project file is using a deprecated version"
+    ):
+        Pipeline.build(
+            version=version,
             actions={
                 "my_action": {
                     "outputs": {"highly_sensitive": {"foo": "bar.txt"}},

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,10 +40,10 @@ def test_action_handles_invalid_version(action):
     data = {
         "version": 4,
         "actions": {
-            "generate_cohort": {
+            "generate_output": {
                 "run": action,
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/input.csv"},
+                    "highly_sensitive": {"output": "output/input.csv"},
                 },
             }
         },
@@ -71,91 +71,19 @@ def test_action_handles_valid_version(action):
     data = {
         "version": 4,
         "actions": {
-            "generate_cohort": {
+            "generate_output": {
                 "run": action,
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/input.csv"},
+                    "highly_sensitive": {"output": "output/input.csv"},
                 },
             }
         },
     }
 
-    run = Pipeline.build(**data).actions["generate_cohort"].run
+    run = Pipeline.build(**data).actions["generate_output"].run
     n, _, v = action.partition(":")
     assert run.name == n
     assert run.version == v
-
-
-def test_action_cohortextractor_multiple_outputs_with_output_flag():
-    data = {
-        "version": 1,
-        "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort --output-dir=output",
-                "outputs": {
-                    "moderately_sensitive": {
-                        "cohort": "output/input.csv",
-                        "other": "other/graph.png",
-                    }
-                },
-            }
-        },
-    }
-
-    run_command = Pipeline.build(**data).actions["generate_cohort"].run.raw
-
-    assert run_command == "cohortextractor:latest generate_cohort --output-dir=output"
-
-
-def test_action_cohortextractor_multiple_ouputs_without_output_flag():
-    data = {
-        "version": 1,
-        "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
-                "outputs": {
-                    "moderately_sensitive": {
-                        "cohort": "output/input.csv",
-                        "other": "other/graph.png",
-                    }
-                },
-            }
-        },
-    }
-
-    msg = (
-        "generate_cohort command should produce output in only one directory, found 2:"
-    )
-    with pytest.raises(ValidationError, match=msg):
-        Pipeline.build(**data)
-
-
-# Note that the behaviour this tests confirms is nonsense, but I don't really want to
-# touch any of the cohortextractor stuff and coverage complains if we don't exercise
-# this logic.
-def test_action_cohortextractor_multiple_ouputs_levels():
-    data = {
-        "version": 1,
-        "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
-                "outputs": {
-                    "highly_sensitive": {
-                        "cohort": "output/input.csv",
-                    },
-                    "moderately_sensitive": {
-                        "other": "other/graph.png",
-                    },
-                },
-            }
-        },
-    }
-
-    msg = (
-        "A `generate_cohort` action must have exactly one output; generate_cohort had 2"
-    )
-    with pytest.raises(ValidationError, match=msg):
-        Pipeline.build(**data)
 
 
 @pytest.mark.parametrize("image", ["databuilder", "ehrql"])
@@ -166,17 +94,17 @@ def test_action_extraction_command_with_less_than_highly_sensitive_output(
     data = {
         "version": 4,
         "actions": {
-            "generate_cohort": {
+            "generate_dataset": {
                 "run": f"{image}:latest generate-dataset",
                 "outputs": {
-                    sensitivity: {"cohort": "output/input.csv"},
+                    sensitivity: {"dataset": "output/input.csv"},
                 },
             }
         },
     }
 
     msg = (
-        "`generate_cohort` action uses `generate-dataset` and so all outputs must "
+        "`generate_dataset` action uses `generate-dataset` and so all outputs must "
         "be labelled `highly_sensitive`"
     )
     with pytest.raises(ValidationError, match=msg):
@@ -218,10 +146,10 @@ def test_action_extraction_command_with_one_outputs():
     data = {
         "version": 4,
         "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
+            "generate_output": {
+                "run": "action:v1 generate_output",
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/input.csv"},
+                    "highly_sensitive": {"dataset": "output/input.csv"},
                 },
             }
         },
@@ -229,7 +157,7 @@ def test_action_extraction_command_with_one_outputs():
 
     config = Pipeline.build(**data)
 
-    outputs = config.actions["generate_cohort"].outputs.dict()
+    outputs = config.actions["generate_output"].outputs.dict()
     assert len(outputs.values()) == 1
 
 
@@ -276,7 +204,7 @@ def test_cohortextractor_actions_not_used_after_v3():
         "version": "4",
         "actions": {
             "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
+                "run": "cohortextractor:v1 generate_cohort",
                 "outputs": {
                     "highly_sensitive": {"cohort": "output/input.csv"},
                 },
@@ -292,22 +220,22 @@ def test_command_properties():
     data = {
         "version": 4,
         "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort another_arg",
-                "outputs": {"highly_sensitive": {"cohort": "output/input.csv"}},
+            "generate_output": {
+                "run": "action:v1 generate_output another_arg",
+                "outputs": {"highly_sensitive": {"output": "output/input.csv"}},
             }
         },
     }
 
-    action = Pipeline.build(**data).actions["generate_cohort"]
-    assert action.run.args == "generate_cohort another_arg"
-    assert action.run.name == "cohortextractor"
+    action = Pipeline.build(**data).actions["generate_output"]
+    assert action.run.args == "generate_output another_arg"
+    assert action.run.name == "action"
     assert action.run.parts == [
-        "cohortextractor:latest",
-        "generate_cohort",
+        "action:v1",
+        "generate_output",
         "another_arg",
     ]
-    assert action.run.version == "latest"
+    assert action.run.version == "v1"
 
 
 def test_pipeline_all_actions(test_file):
@@ -329,44 +257,44 @@ def test_pipeline_needs_success():
     data = {
         "version": 4,
         "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
-                "outputs": {"highly_sensitive": {"cohort": "output/input.csv"}},
+            "generate_output": {
+                "run": "action:v1 generate_output",
+                "outputs": {"highly_sensitive": {"output": "output/input.csv"}},
             },
             "do_analysis": {
                 "run": "python:latest foo.py",
-                "outputs": {"highly_sensitive": {"cohort2": "output/input2.csv"}},
-                "needs": ["generate_cohort"],
+                "outputs": {"highly_sensitive": {"output2": "output/input2.csv"}},
+                "needs": ["generate_output"],
             },
         },
     }
 
     config = Pipeline.build(**data)
 
-    assert config.actions["do_analysis"].needs == ["generate_cohort"]
+    assert config.actions["do_analysis"].needs == ["generate_output"]
 
 
 def test_pipeline_needs_with_non_comma_delimited_actions():
     data = {
         "version": 4,
         "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
-                "outputs": {"moderately_sensitive": {"cohort": "output/input.csv"}},
+            "generate_output": {
+                "run": "action:v1 generate_output",
+                "outputs": {"moderately_sensitive": {"output": "output/input.csv"}},
             },
             "do_analysis": {
                 "run": "python:latest foo.py",
-                "outputs": {"moderately_sensitive": {"cohort2": "output/input2.csv"}},
+                "outputs": {"moderately_sensitive": {"output2": "output/input2.csv"}},
             },
             "do_further_analysis": {
                 "run": "python:latest foo2.py",
-                "needs": ["generate_cohort do_analysis"],
-                "outputs": {"moderately_sensitive": {"cohort3": "output/input3.csv"}},
+                "needs": ["generate_output do_analysis"],
+                "outputs": {"moderately_sensitive": {"output3": "output/input3.csv"}},
             },
         },
     }
 
-    msg = "`needs` actions should be separated with commas, but do_further_analysis needs `generate_cohort do_analysis`"
+    msg = "`needs` actions should be separated with commas, but do_further_analysis needs `generate_output do_analysis`"
     with pytest.raises(ValidationError, match=msg):
         Pipeline.build(**data)
 
@@ -379,7 +307,7 @@ def test_pipeline_needs_with_unknown_action():
                 "run": "test:latest",
                 "needs": ["action2"],
                 "outputs": {
-                    "moderately_sensitive": {"cohort": "output.csv"},
+                    "moderately_sensitive": {"dataset": "output.csv"},
                 },
             },
         },
@@ -397,13 +325,13 @@ def test_pipeline_with_duplicated_action_run_commands():
             "action1": {
                 "run": "test:latest",
                 "outputs": {
-                    "moderately_sensitive": {"cohort": "output.csv"},
+                    "moderately_sensitive": {"dataset": "output.csv"},
                 },
             },
             "action2": {
                 "run": "test:latest",
                 "outputs": {
-                    "moderately_sensitive": {"cohort": "output.csv"},
+                    "moderately_sensitive": {"dataset": "output.csv"},
                 },
             },
         },
@@ -437,7 +365,7 @@ def test_pipeline_with_empty_run_command():
             "action1": {
                 "run": "",
                 "outputs": {
-                    "moderately_sensitive": {"cohort": "output.csv"},
+                    "moderately_sensitive": {"dataset": "output.csv"},
                 },
             },
         },
@@ -466,7 +394,7 @@ def test_pipeline_with_missing_or_none_version():
         "actions": {
             "action1": {
                 "run": "test",
-                "outputs": {"highly_sensitive": {"cohort": "output.csv"}},
+                "outputs": {"highly_sensitive": {"dataset": "output.csv"}},
             },
         },
     }
@@ -486,7 +414,7 @@ def test_pipeline_with_non_numeric_version():
         "actions": {
             "action1": {
                 "run": "test",
-                "outputs": {"highly_sensitive": {"cohort": "output.csv"}},
+                "outputs": {"highly_sensitive": {"output": "output.csv"}},
             },
         },
     }
@@ -502,11 +430,11 @@ def test_outputs_files_are_unique():
     data = {
         "version": 4,
         "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
+            "generate_output": {
+                "run": "action:v1 generate_output",
                 "outputs": {
                     "highly_sensitive": {
-                        "cohort": "output/input.csv",
+                        "output": "output/input.csv",
                         "test": "output/input.csv",
                     }
                 },
@@ -517,30 +445,6 @@ def test_outputs_files_are_unique():
     msg = "Output path output/input.csv is not unique"
     with pytest.raises(ValidationError, match=msg):
         Pipeline.build(**data)
-
-
-def test_outputs_duplicate_files_in_v1():
-    data = {
-        "version": 1,
-        "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
-                "outputs": {
-                    "highly_sensitive": {
-                        "cohort": "output/input.csv",
-                        "test": "output/input.csv",
-                    }
-                },
-            },
-        },
-    }
-
-    generate_cohort = Pipeline.build(**data).actions["generate_cohort"]
-
-    cohort = generate_cohort.outputs.highly_sensitive["cohort"]
-    test = generate_cohort.outputs.highly_sensitive["test"]
-
-    assert cohort == test
 
 
 def test_outputs_with_unknown_privacy_level():
@@ -567,7 +471,7 @@ def test_outputs_with_unknown_privacy_level():
                 "actions": {
                     "action1": {
                         "run": "test",
-                        "outputs": {"test": {"cohort": "output/input.csv"}},
+                        "outputs": {"test": {"dataset": "output/input.csv"}},
                     }
                 },
             }
@@ -578,8 +482,8 @@ def test_outputs_with_invalid_pattern():
     data = {
         "version": 4,
         "actions": {
-            "generate_cohort": {
-                "run": "cohortextractor:latest generate_cohort",
+            "generate_output": {
+                "run": "action:v1 generate_output",
                 "outputs": {"highly_sensitive": {"test": "test/foo"}},
             },
         },
@@ -659,19 +563,9 @@ def test_pipeline_databuilder_recognizes_old_action_spelling():
             True,
         ),
         (
-            "generate_cohort",
-            "cohortextractor:latest generate_cohort args --option",
-            True,
-        ),
-        (
             "generate_databuilder_dataset",
             "databuilder:v0 generate-dataset args --output=output/input.csv",
             True,
-        ),
-        (
-            "generate_cohortextractor_measures",
-            "cohortextractor:latest generate_measures args --option",
-            False,
         ),
         (
             "non_db_generate_measures",
@@ -703,25 +597,25 @@ def test_action_images():
             "ehrql": {
                 "run": "ehrql:v1 ...",
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/ehrql.csv"},
+                    "highly_sensitive": {"dataset": "output/ehrql.csv"},
                 },
             },
             "r1": {
                 "run": "r:latest 1",
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/r1.csv"},
+                    "highly_sensitive": {"dataset": "output/r1.csv"},
                 },
             },
             "r2": {
                 "run": "r:latest 2",
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/r2.csv"},
+                    "highly_sensitive": {"dataset": "output/r2.csv"},
                 },
             },
             "python": {
                 "run": "python:v2 ...",
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/python.csv"},
+                    "highly_sensitive": {"dataset": "output/python.csv"},
                 },
             },
         },
@@ -738,25 +632,25 @@ def test_action_images_v5():
             "ehrql": {
                 "run": "ehrql:v1 ...",
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/ehrql.csv"},
+                    "highly_sensitive": {"dataset": "output/ehrql.csv"},
                 },
             },
             "r1": {
                 "run": "r:v1 1",
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/r1.csv"},
+                    "highly_sensitive": {"dataset": "output/r1.csv"},
                 },
             },
             "r2": {
                 "run": "r:v2 2",
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/r2.csv"},
+                    "highly_sensitive": {"dataset": "output/r2.csv"},
                 },
             },
             "python": {
                 "run": "python:v2 ...",
                 "outputs": {
-                    "highly_sensitive": {"cohort": "output/python.csv"},
+                    "highly_sensitive": {"dataset": "output/python.csv"},
                 },
             },
         },

--- a/tests/test_type_validation.py
+++ b/tests/test_type_validation.py
@@ -10,21 +10,14 @@ def test_missing_actions():
     with pytest.raises(
         ValidationError, match="Project `actions` section must be a dictionary"
     ):
-        Pipeline.build(version=3, expectations={"population_size": 10})
+        Pipeline.build(version=4)
 
 
 def test_actions_incorrect_type():
     with pytest.raises(
         ValidationError, match="Project `actions` section must be a dictionary"
     ):
-        Pipeline.build(version=3, actions=[], expectations={"population_size": 10})
-
-
-def test_expectations_incorrect_type():
-    with pytest.raises(
-        ValidationError, match="Project `expectations` section must be a dictionary"
-    ):
-        Pipeline.build(version=3, actions={}, expectations=[])
+        Pipeline.build(version=4, actions=[])
 
 
 def test_outputs_incorrect_type():
@@ -33,9 +26,8 @@ def test_outputs_incorrect_type():
         match="`outputs` section for action action1 must be a dictionary",
     ):
         Pipeline.build(
-            version=3,
+            version=4,
             actions={"action1": {"outputs": [], "run": "test:v1"}},
-            expectations={"population_size": 10},
         )
 
 
@@ -44,9 +36,8 @@ def test_run_incorrect_type():
         ValidationError, match="`run` section for action action1 must be a string"
     ):
         Pipeline.build(
-            version=3,
+            version=4,
             actions={"action1": {"outputs": {}, "run": ["test:v1"]}},
-            expectations={"population_size": 10},
         )
 
 
@@ -55,9 +46,8 @@ def test_needs_incorrect_type():
         ValidationError, match="`needs` section for action action1 must be a list"
     ):
         Pipeline.build(
-            version=3,
+            version=4,
             actions={"action1": {"outputs": {}, "run": "test:v1", "needs": ""}},
-            expectations={"population_size": 10},
         )
 
 
@@ -67,9 +57,8 @@ def test_config_incorrect_type():
         match="`config` section for action action1 must be a dictionary",
     ):
         Pipeline.build(
-            version=3,
+            version=4,
             actions={"action1": {"outputs": {}, "run": "test:v1", "config": []}},
-            expectations={"population_size": 10},
         )
 
 
@@ -79,11 +68,10 @@ def test_dummy_data_file_incorrect_type():
         match="`dummy_data_file` section for action action1 must be a string",
     ):
         Pipeline.build(
-            version=3,
+            version=4,
             actions={
                 "action1": {"outputs": {}, "run": "test:v1", "dummy_data_file": []}
             },
-            expectations={"population_size": 10},
         )
 
 
@@ -93,11 +81,10 @@ def test_output_files_incorrect_type():
         match="`highly_sensitive` section for action action1 must be a dictionary",
     ):
         Pipeline.build(
-            version=3,
+            version=4,
             actions={
                 "action1": {"outputs": {"highly_sensitive": []}, "run": "test:v1"}
             },
-            expectations={"population_size": 10},
         )
 
 
@@ -107,14 +94,13 @@ def test_output_filename_incorrect_type():
         match="`dataset` output for action action1 must be a string",
     ):
         Pipeline.build(
-            version=3,
+            version=4,
             actions={
                 "action1": {
                     "outputs": {"highly_sensitive": {"dataset": {}}},
                     "run": "test:v1",
                 }
             },
-            expectations={"population_size": 10},
         )
 
 
@@ -131,7 +117,7 @@ def test_action_extra_parameters():
         match=re.escape("Unexpected parameters (extra) in action action1"),
     ):
         Pipeline.build(
-            version=3,
+            version=4,
             actions={
                 "action1": {
                     "outputs": {},
@@ -139,7 +125,6 @@ def test_action_extra_parameters():
                     "extra": 123,
                 }
             },
-            expectations={"population_size": 10},
         )
 
 
@@ -151,26 +136,11 @@ def test_outputs_extra_parameters():
         ),
     ):
         Pipeline.build(
-            version=3,
+            version=4,
             actions={
                 "action1": {
                     "outputs": {"highly_sensitive": {"dataset": {}}, "extra": 123},
                     "run": "test:v1",
                 }
             },
-            expectations={"population_size": 10},
-        )
-
-
-def test_expectations_extra_parameters():
-    with pytest.raises(
-        ValidationError,
-        match=re.escape(
-            "Unexpected parameters (extra) in project `expectations` section"
-        ),
-    ):
-        Pipeline.build(
-            version=3,
-            actions={},
-            expectations={"population_size": 10, "extra": 123},
         )


### PR DESCRIPTION
It's no longer possible to run a project with a project.yaml version that isn't compatible with version 4, which removed support for cohort-extractor.

This sets a MINIMUM_VERSION in features.py, and raises a validation error if the version is < 4. This means we can get rid of a bunch of code and validation that only exists to support/validate very old versions and old cohort-extractor features.

This will break a few existing projects, because they are using v3 and still have an `expectations` section, which v4 doesn't allow. However, it only applies to about 10 projects and we can easily make PRs to update those (preferably straight to v5, which will also mean fewer studies that have to deal with changes when we enforce v5, in order to disallow use of `latest`). Updating project.yamls to v4 / v5 with latest -> v1 does not make any actual change to the way the project actions run.

This PR is draft until existing projects that are still on v3 are updated.